### PR TITLE
Mobile styling added, fixed footer mobile styling page overflow

### DIFF
--- a/src/components/atoms/calendar-dates/calendar-dates.module.css
+++ b/src/components/atoms/calendar-dates/calendar-dates.module.css
@@ -7,7 +7,6 @@
 
 .slideTray {
   display: flex;
-  justify-content: center;
   align-items: center;
   color: white;
   gap: 4rem;
@@ -45,4 +44,10 @@
   100% {
     opacity: 1;
   }
+}
+
+@media (min-width: 1024px) {
+  .slideTray {
+    justify-content: center;
+}
 }

--- a/src/components/atoms/fixture-card/fixture-card.module.css
+++ b/src/components/atoms/fixture-card/fixture-card.module.css
@@ -2,25 +2,40 @@
   height: 100%;
   display: flex;
   width: 100%;
-  gap: 1.5rem;
   flex-direction: column;
   justify-content: space-evenly;
 }
 
 .game {
   display: flex;
+  justify-content: space-between;
   gap: 2rem;
   font-family: helvetica;
   color: rgb(255, 250, 251);
-  font-size: 30px;
+  font-size: 22px;
   align-items: center;
 }
 
 .game > p:first-child {
-  font-size: 40px;
+  font-size: 30px;
 }
 
 .game:hover {
   color: rgb(103, 244, 140);
   cursor: default;
+}
+
+@media (min-width: 1024px) {
+  .container {
+    gap: 1.5rem;
+  }
+
+  .game {
+    font-size: 30px;
+    justify-content: flex-start;
+  }
+
+  .game > p:first-child {
+    font-size: 40px;
+  }
 }

--- a/src/components/atoms/util-links/util-links.module.css
+++ b/src/components/atoms/util-links/util-links.module.css
@@ -1,27 +1,27 @@
 .utilities {
-    border-top: solid thick rgb(62, 62, 62);
-    width: 80%;
-    height: 30%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  border-top: solid thick rgb(62, 62, 62);
+  width: 80%;
+  height: 30%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.utilities  > ul { 
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-evenly;
-    list-style: none;
-    width: 100%;
-    height: 70%;
+.utilities > ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  list-style: none;
+  width: 100%;
+  height: 70%;
 }
 
 .link > a {
-    margin: 0 10px;
-    color: gray;
-    text-decoration: none;
+  margin: 0 10px;
+  color: gray;
+  text-decoration: none;
 }
 
 .link > a:hover {
-    color: white;
+  color: white;
 }

--- a/src/components/atoms/years/years.module.css
+++ b/src/components/atoms/years/years.module.css
@@ -9,14 +9,15 @@
   font-style: italic;
   font-weight: 1000;
   top: 20%;
+  gap: 10%;
 }
 
 .years {
-  font-size: 10%
+  font-size: 4rem;
+  animation: boble 2s infinite ease-in-out alternate;
 }
 
 .years:hover {
-  animation: boble 0.5s infinite ease-in-out alternate;
   cursor: pointer;
 }
 
@@ -25,7 +26,7 @@
 }
 
 .active_2024 > p {
-  font-size: 15rem;
+  font-size: 4rem;
 }
 
 .active_2025 {
@@ -33,7 +34,7 @@
 }
 
 .active_2025 > p {
-  font-size: 15rem;
+  font-size: 4rem;
 }
 
 .year_shadow {
@@ -47,18 +48,63 @@
   display: none;
 }
 
-@media (min-width: 1024px) {
-  .years_container {
-    gap: 4rem;
-  }
-
-  .years {
-    font-size: 10vw;
-  }
-}
-
 @keyframes boble {
   100% {
     transform: scale(1.1);
+  }
+}
+
+@media (min-width: 1024px) {
+  .years_container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    position: absolute;
+    color: white;
+    font-family: sans-serif;
+    font-style: italic;
+    font-weight: 1000;
+    top: 20%;
+    gap: 5%;
+  }
+
+  .years {
+    font-size: 10%
+  }
+
+  .years:hover {
+    cursor: pointer;
+  }
+
+  .active_2024 {
+    color: rgb(103, 244, 140);
+  }
+
+  .active_2024 > p {
+    font-size: 15rem;
+  }
+
+  .active_2025 {
+    color: rgb(103, 244, 140);
+  }
+
+  .active_2025 > p {
+    font-size: 15rem;
+  }
+
+  .year_shadow {
+    position: absolute;
+    color: white;
+    z-index: 1;
+    top: 15%;
+  }
+
+  .hide {
+    display: none;
+  }
+
+  .years {
+      font-size: 10vw;
   }
 }

--- a/src/components/molecules/fixture-hud/fixture-hud.module.css
+++ b/src/components/molecules/fixture-hud/fixture-hud.module.css
@@ -8,12 +8,13 @@
   justify-content: space-evenly;
   align-items: center;
   top: 13%;
-  width: 40%;
+  width: 90%;
   height: 60%;
   background: #231F20;
   border-radius: 10%;
   flex-direction: column-reverse;
   z-index: 1;
+  opacity: 0.9;
 }
 
 .active {
@@ -45,4 +46,20 @@
 .exit:hover {
   color: gray;
   cursor: pointer;
+}
+
+@media (min-width: 1024px) {
+  .true {
+    display: flex;
+    position: absolute;
+    justify-content: space-evenly;
+    align-items: center;
+    top: 13%;
+    width: 40%;
+    height: 60%;
+    background: #231F20;
+    border-radius: 10%;
+    flex-direction: column-reverse;
+    z-index: 1;
+  }
 }

--- a/src/components/molecules/footer/footer.module.css
+++ b/src/components/molecules/footer/footer.module.css
@@ -1,44 +1,57 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    margin: 3.2rem 0 0;
-    height: 35vh;
-    background-color: black;
-    color: white;
-    align-items: center;
-    justify-content: space-evenly;
-    white-space: nowrap;
-    padding: 2.5rem 0 0 0;
-
-    font-family: "Open Sans", sans-serif;
+  display: flex;
+  flex-direction: column;
+  margin: 3.2rem 0 0;
+  background-color: black;
+  color: white;
+  align-items: center;
+  justify-content: space-evenly;
+  white-space: nowrap;
+  padding: 2.5rem 0;
+  gap: 1rem;
+  font-family: "Open Sans", sans-serif;
 }
 
 .links {
-    display: flex;
-    justify-content: center;
-    list-style: none;
-    font-weight: 600;
-    font-size: 18px;
+  display: inline-block;
+  columns: 2;
+  padding: 0;
+  flex-direction: column;
+  justify-content: center;
+  list-style: none;
+  font-weight: 600;
+  font-size: 18px;
 }
 
 .links > li {
-    padding: 0 10% 0;
+  margin: 0 0 1rem 2rem;
 }
 
 .links > li:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .socials {
-    flex-direction: column;
-    border-top: solid thick rgb(62, 62, 62);
-    width: 80%;
-    height: 30%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  flex-direction: column;
+  border-top: solid thick rgb(62, 62, 62);
+  width: 80%;
+  height: 30%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.socials >  h5 {
-    padding: 20px 0 0;
+.socials > h5 {
+  padding: 20px 0 0;
+}
+
+@media (min-width: 1024px) { 
+  .links {
+    display: flex;
+    flex-direction: row;
+    columns: 1;
+  }
+  .links > li {
+    margin: 0 3rem;
+  }
 }

--- a/src/components/molecules/game-fixtures-section/game-fixtures-section.module.css
+++ b/src/components/molecules/game-fixtures-section/game-fixtures-section.module.css
@@ -1,6 +1,6 @@
 .main {
   position: relative;
-  height: 100vh;
+  height: 85vh;
   width: 100%;
   background-color: black;
   display: flex;
@@ -64,6 +64,10 @@
 }
 
 @media (min-width: 1024px) {
+  .main {
+    height: 100vh;
+  }
+
   .years_container {
     gap: 4rem;
   }


### PR DESCRIPTION
Changes:

- Added mobile breakpoints to the stylings used in the Game Fixtures Section. 
- Added mobile breakpoints to the Footer and added styling to fix the positioning of the component and stop the page overflow, when switching to mobile. 

(There was an issue where when I switched to mobile, you could scroll to the right, taking you out of the page content. Noticed that it was because the footer was rendering links in a flex-row, which caused the elements to get out of the page and add extra content to it.)

